### PR TITLE
Use different method to open OmniFocus URL?

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -24,7 +24,7 @@ async function handleBrowserActionClick() {
       note: activeTab.url
     })
 
-    openOmniFocusUrl(addTaskUrl)
+    openOmniFocusUrl(addTaskUrl, activeTab)
 
     console.info(browser.i18n.getMessage('infoTaskSent', [activeTab.title]))
   } else {
@@ -39,7 +39,7 @@ function handleMenuClick(info, tab) {
   }
 }
 
-function handleMenuClickForLink({ linkText, linkUrl, pageUrl }, _tab) {
+function handleMenuClickForLink({ linkText, linkUrl, pageUrl }, tab) {
   const addTaskUrl = composeOmniFocusAddTaskUrl({
     name: linkText,
     note: composeMultiLineNote([
@@ -49,15 +49,15 @@ function handleMenuClickForLink({ linkText, linkUrl, pageUrl }, _tab) {
     ])
   })
 
-  openOmniFocusUrl(addTaskUrl)
+  openOmniFocusUrl(addTaskUrl, tab)
 
   console.info(browser.i18n.getMessage('infoTaskSent', [linkText]))
 }
 
-function openOmniFocusUrl(url) {
+function openOmniFocusUrl(url, tab) {
   // This is a little gross, but I haven’t been able to find a neater way to
   // open the OmniFocus URL, and this appears to have no side effects.
-  location = url
+  browser.tabs.update(tab.id, { url })
 }
 
 browser.browserAction.onClicked.addListener(handleBrowserActionClick)


### PR DESCRIPTION
I experienced the problem in #5 and #6 in Firefox 85 and did some investigating. 

I found that changing the `location` in the background page context doesn't seem to do anything. I experimented a bit and this PR seems to do the desired thing: opening the OmniFocus quick entry form (provided OF has been accepted as the default handler for such URLs) without actually navigating the original tab.

I think this approach might do to get this extension working in recent Firefox releases. If so, it would fix #5 and fix #6.

(I did some digging through Firefox bugs and wasn't able to figure out what seems to have changed in Firefox 84—sorry about that.)